### PR TITLE
GHC-9.0 support

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -145,6 +145,15 @@ jobs:
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
+      - name: install cabal-docspec
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20201230.1/cabal-docspec-0.0.0.20201230.1.xz > cabal-docspec.xz
+          echo '18caf4f361fadd978782f08e78f42d21d4f177567419055ffccae19b8214852d  cabal-docspec.xz' | sha256sum -c -
+          xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
+          rm -f cabal-docspec.xz
+          chmod a+x $HOME/.cabal/bin/cabal-docspec
+          cabal-docspec --version
       - name: checkout
         uses: actions/checkout@v2
         with:
@@ -189,6 +198,10 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
+      - name: docspec
+        run: |
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all
+          cabal-docspec $ARG_COMPILER
       - name: cabal check
         run: |
           cd ${PKGDIR_unique} || false

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+## 0.0.0.1
+
+* GHC-9.0 compatibility
+
 ## 0
 
 * Repository initialized

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,3 +2,4 @@ branches:               master
 no-tests-no-benchmarks: False
 unconstrained:          False
 irc-channels:           irc.freenode.org#haskell-lens
+docspec:                True

--- a/src/Control/Concurrent/Unique.hs
+++ b/src/Control/Concurrent/Unique.hs
@@ -11,8 +11,7 @@ module Control.Concurrent.Unique
 
 import Data.Hashable
 import GHC.IO
-import GHC.Prim
-import GHC.Types
+import GHC.Exts
 
 -- | Unique identifiers are created by creating heap objects in kind # that
 -- can be compared for value equality and then hashing them using their initial allocation

--- a/src/Control/Concurrent/Unique.hs
+++ b/src/Control/Concurrent/Unique.hs
@@ -13,9 +13,31 @@ import Data.Hashable
 import GHC.IO
 import GHC.Exts
 
+-- $setup
+-- >>> import Data.Hashable
+
 -- | Unique identifiers are created by creating heap objects in kind # that
 -- can be compared for value equality and then hashing them using their initial allocation
 -- address.
+--
+-- >>> x <- newUnique
+-- >>> y <- newUnique
+-- >>> z <- newUnique
+--
+-- >>> [x == x, y == y, z == z]
+-- [True,True,True]
+--
+-- >>> [x == y, y == z, z == x]
+-- [False,False,False]
+--
+-- The hashes could be same, in theory, but in practice they are different
+-- as well.
+--
+-- >>> [ hash x == hash x, hash y == hash y, hash z == hash z]
+-- [True,True,True]
+--
+-- >>> [ hash x == hash y, hash y == hash z, hash z == hash x]
+-- [False,False,False]
 
 -- TODO: If, due to a small heap size we find we have high collision rate on initial allocation location
 -- we might consider upgrading this initial hash with something fast and volatile, e.g. rdtsc

--- a/unique.cabal
+++ b/unique.cabal
@@ -1,6 +1,6 @@
 name:          unique
 category:      Concurrency, Data
-version:       0
+version:       0.0.0.1
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE
@@ -38,5 +38,4 @@ library
   ghc-options: -Wall
   build-depends:
     base     >= 4.5 && < 5,
-    hashable >= 1.1 && < 1.4,
-    ghc-prim
+    hashable >= 1.1 && < 1.4


### PR DESCRIPTION
The change is triggered by `unsafeCoerce#` moving around.