### PR TITLE
Allow building with hashable == 1.5.*

### DIFF
--- a/unique.cabal
+++ b/unique.cabal
@@ -38,4 +38,4 @@ library
   ghc-options: -Wall
   build-depends:
     base     >= 4.5 && < 5,
-    hashable >= 1.1 && < 1.5
+    hashable >= 1.1 && < 1.6


### PR DESCRIPTION
A hackage revision for this change would also be useful.